### PR TITLE
Fix: replace deprecated Request::get() usages with query() for Symfon…

### DIFF
--- a/app/Http/Controllers/ArsipController.php
+++ b/app/Http/Controllers/ArsipController.php
@@ -15,7 +15,7 @@ class ArsipController extends Controller
     {
         $tahun = ShareLink::getTahunByToken($token);
         $dipa = Dipa::getByTahun($tahun);
-        $search = request()->get('search');
+        $search = request()->query('search');
         $data = Dipa::getMataAnggarans(! empty($dipa) ? $dipa->id : null, $search)
             ->paginate()
             ->withQueryString();
@@ -33,7 +33,7 @@ class ArsipController extends Controller
     public function perKak($token, $coa)
     {
         $tahun = ShareLink::getTahunByToken($token);
-        $search = request()->get('search');
+        $search = request()->query('search');
         $data = KerangkaAcuan::getKerangkaAcuans($coa, $search)
             ->paginate()
             ->withQueryString();
@@ -55,7 +55,7 @@ class ArsipController extends Controller
         $path = $tahun.'/'.'arsip-dokumens'.'/'.$kakId;
         $files = Storage::disk('arsip')->files($path);
         $perPage = 15;
-        $page = request()->get('page', 1);
+        $page = request()->query('page', 1);
         $offset = ($page - 1) * $perPage;
         $data = array_slice($files, $offset, $perPage);
         $data = (new \Illuminate\Pagination\LengthAwarePaginator($data, count($files), $perPage, $page, [

--- a/app/Models/ShareLink.php
+++ b/app/Models/ShareLink.php
@@ -21,7 +21,7 @@ class ShareLink extends Model
     {
         $tahun = $this->where('token', $token)->first()->tahun;
         $dipa = Dipa::where('tahun', $tahun)->first();
-        $search = request()->get('search');
+        $search = request()->query('search');
         $data = DB::table('mata_anggarans')
             ->select(['mak', 'id', 'uraian'])
             ->where('dipa_id', ! empty($dipa) ? $dipa->id : null)

--- a/app/Nova/ArsipDokumen.php
+++ b/app/Nova/ArsipDokumen.php
@@ -155,7 +155,7 @@ class ArsipDokumen extends Resource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if (empty($request->get('orderBy'))) {
+        if (empty($request->query('orderBy'))) {
             $query->getQuery()->orders = [];
 
             // Sort numerik

--- a/app/Nova/DaftarPenilaianReward.php
+++ b/app/Nova/DaftarPenilaianReward.php
@@ -158,7 +158,7 @@ class DaftarPenilaianReward extends Resource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if (empty($request->get('orderBy'))) {
+        if (empty($request->query('orderBy'))) {
             $query->getQuery()->orders = [];
 
             return $query->orderBy(key(static::$indexDefaultOrder), reset(static::$indexDefaultOrder));

--- a/app/Nova/DokumentasiKegiatan.php
+++ b/app/Nova/DokumentasiKegiatan.php
@@ -151,7 +151,7 @@ class DokumentasiKegiatan extends Resource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if (empty($request->get('orderBy'))) {
+        if (empty($request->query('orderBy'))) {
             $query->getQuery()->orders = [];
 
             $query->orderBy(key(static::$indexDefaultOrder), reset(static::$indexDefaultOrder));

--- a/app/Nova/IzinKeluar.php
+++ b/app/Nova/IzinKeluar.php
@@ -73,7 +73,7 @@ class IzinKeluar extends Resource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if (empty($request->get('orderBy'))) {
+        if (empty($request->query('orderBy'))) {
             $query->getQuery()->orders = [];
 
             $query->orderBy(key(static::$indexDefaultOrder), reset(static::$indexDefaultOrder));

--- a/app/Nova/JenisBelanja.php
+++ b/app/Nova/JenisBelanja.php
@@ -105,7 +105,7 @@ class JenisBelanja extends Resource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if (empty($request->get('orderBy'))) {
+        if (empty($request->query('orderBy'))) {
             $query->getQuery()->orders = [];
 
             return $query->orderBy(key(static::$indexDefaultOrder), reset(static::$indexDefaultOrder));

--- a/app/Nova/NaskahKeluar.php
+++ b/app/Nova/NaskahKeluar.php
@@ -46,7 +46,7 @@ class NaskahKeluar extends Resource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if (empty($request->get('orderBy'))) {
+        if (empty($request->query('orderBy'))) {
             $query->getQuery()->orders = [];
 
             $query->orderBy(key(static::$indexDefaultOrder), reset(static::$indexDefaultOrder));

--- a/app/Nova/NaskahMasuk.php
+++ b/app/Nova/NaskahMasuk.php
@@ -41,7 +41,7 @@ class NaskahMasuk extends Resource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if (empty($request->get('orderBy'))) {
+        if (empty($request->query('orderBy'))) {
             $query->getQuery()->orders = [];
 
             $query->orderBy(key(static::$indexDefaultOrder), reset(static::$indexDefaultOrder));

--- a/app/Nova/RewardPegawai.php
+++ b/app/Nova/RewardPegawai.php
@@ -336,7 +336,7 @@ class RewardPegawai extends Resource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if (empty($request->get('orderBy'))) {
+        if (empty($request->query('orderBy'))) {
             $query->getQuery()->orders = [];
 
             // Sort numerik

--- a/app/Nova/TargetKkp.php
+++ b/app/Nova/TargetKkp.php
@@ -114,7 +114,7 @@ class TargetKkp extends Resource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if (empty($request->get('orderBy'))) {
+        if (empty($request->query('orderBy'))) {
             $query->getQuery()->orders = [];
 
             return $query->orderBy(key(static::$indexDefaultOrder), reset(static::$indexDefaultOrder));

--- a/app/Nova/TargetSerapanAnggaran.php
+++ b/app/Nova/TargetSerapanAnggaran.php
@@ -121,7 +121,7 @@ class TargetSerapanAnggaran extends Resource
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        if (empty($request->get('orderBy'))) {
+        if (empty($request->query('orderBy'))) {
             $query->getQuery()->orders = [];
 
             return $query->orderBy(key(static::$indexDefaultOrder), reset(static::$indexDefaultOrder));


### PR DESCRIPTION
…y 7.4 compatibility (Nova indexQuery orderBy, controller search/page). No behavior change.