### PR TITLE
Fix: add null coalescing to json_decode, round, explode calls for PHP…

### DIFF
--- a/app/Console/Commands/SimpedeRestore.php
+++ b/app/Console/Commands/SimpedeRestore.php
@@ -546,7 +546,7 @@ class SimpedeRestore extends Command
             $bytes /= 1024;
         }
 
-        return round($bytes, $precision).' '.$units[$i];
+        return round($bytes ?? 0, $precision).' '.$units[$i];
     }
 
     private function dropAllTables()

--- a/app/Helpers/Api.php
+++ b/app/Helpers/Api.php
@@ -20,7 +20,7 @@ class Api
         $process = Process::fromShellCommandline($composer.' outdated '.$flag.' -f json', base_path(), ['COMPOSER_HOME' => $home]);
         $process->run();
         $value = $process->getOutput();
-        $data = json_decode($value, true);
+        $data = json_decode($value ?? '', true);
         $process = Process::fromShellCommandline($composer.' clear-cache', base_path(), ['COMPOSER_HOME' => $home]);
         $process->run();
 

--- a/app/Helpers/GoogleDriveQuota.php
+++ b/app/Helpers/GoogleDriveQuota.php
@@ -32,8 +32,8 @@ class GoogleDriveQuota
                 $limit = $about['storageQuota']['limit'] ?? 0;
                 $usage = $about['storageQuota']['usage'] ?? 0;
 
-                $total = $limit ? round($limit / (1024 ** 3), 2) : 0;
-                $used = $usage ? round($usage / (1024 ** 3), 2) : 0;
+                $total = $limit ? round(($limit ?? 0) / (1024 ** 3), 2) : 0;
+                $used = $usage ? round(($usage ?? 0) / (1024 ** 3), 2) : 0;
             }
         }
 

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -450,7 +450,7 @@ class Helper
      */
     public static function namaTanpaGelar($nama)
     {
-        return explode(',', $nama)[0];
+        return explode(',', $nama ?? '')[0];
     }
 
     /**
@@ -739,7 +739,7 @@ class Helper
         if (isset($queries[$filterUri])) {
             $filters = array_merge(
                 ...json_decode(
-                    base64_decode($queries[$filterUri], true),
+                    base64_decode($queries[$filterUri], true) ?? '',
                     true
                 )
             );
@@ -765,7 +765,7 @@ class Helper
         $filterValue = $defaultValue ?? '';
         $filters = array_merge(
             ...json_decode(
-                base64_decode($filter, true),
+                base64_decode($filter, true) ?? '',
                 true
             ));
 
@@ -1477,7 +1477,7 @@ class Helper
             $item['jabatan'] = 'Mitra Statistik';
             $item['volume'] = $item['volume_realisasi'];
             $item['bruto'] = $item['volume_realisasi'] * $item['harga_satuan'];
-            $item['pajak'] = round($item['volume_realisasi'] * $item['harga_satuan'] * $item['persen_pajak'] / 100, 0, PHP_ROUND_HALF_UP);
+            $item['pajak'] = round(($item['volume_realisasi'] ?? 0) * ($item['harga_satuan'] ?? 0) * ($item['persen_pajak'] ?? 0) / 100, 0, PHP_ROUND_HALF_UP);
             $item['netto'] = $item['bruto'] - $item['pajak'];
             unset($item['mitra_id']);
             unset($item['id']);
@@ -1580,7 +1580,7 @@ class Helper
             $item['kode_bank_id'] = optional($pegawai)->kode_bank_id;
             $item['golongan'] = optional(self::getDataPegawaiByUserId($item['user_id'], $tanggal_spj))->golongan;
             $item['bruto'] = $item['volume'] * $item['harga_satuan'];
-            $item['pajak'] = round($item['volume'] * $item['harga_satuan'] * $item['persen_pajak'] / 100, 0, PHP_ROUND_HALF_UP);
+            $item['pajak'] = round(($item['volume'] ?? 0) * ($item['harga_satuan'] ?? 0) * ($item['persen_pajak'] ?? 0) / 100, 0, PHP_ROUND_HALF_UP);
             $item['netto'] = $item['bruto'] - $item['pajak'];
             unset($item['user_id']);
             unset($item['id']);

--- a/app/Helpers/Policy.php
+++ b/app/Helpers/Policy.php
@@ -20,7 +20,6 @@ class Policy
      * Check if the user has access based on roles.
      *
      * @param  array  $roles
-     * @return bool
      */
     private static function hasAccess($roles): bool
     {
@@ -29,8 +28,6 @@ class Policy
 
     /**
      * Get the current access status.
-     *
-     * @return bool
      */
     public function get(): bool
     {
@@ -39,26 +36,20 @@ class Policy
 
     /**
      * Set access allowed for specific roles.
-     *
-     * @param  string  $roles
-     * @return self
      */
     public function allowedFor(string $roles = 'all'): self
     {
-        $this->allowed = $roles === 'all' || self::hasAccess(explode(',', $roles), session('role'));
+        $this->allowed = $roles === 'all' || self::hasAccess(explode(',', $roles ?? ''), session('role'));
 
         return $this;
     }
 
     /**
      * Set access not allowed for specific roles.
-     *
-     * @param  string  $roles
-     * @return self
      */
     public function notAllowedFor(string $roles = 'all'): self
     {
-        $this->allowed = $roles !== 'all' && self::hasAccess(array_diff(array_keys(Helper::ROLE), explode(',', $roles)), session('role'));
+        $this->allowed = $roles !== 'all' && self::hasAccess(array_diff(array_keys(Helper::ROLE), explode(',', $roles ?? '')), session('role'));
 
         return $this;
     }
@@ -67,7 +58,6 @@ class Policy
      * Set access allowed for a specific year.
      *
      * @param  mixed  $year
-     * @return self
      */
     public function withYear($year): self
     {
@@ -82,7 +72,6 @@ class Policy
      * @param  mixed  $expr1
      * @param  mixed  $expr2
      * @param  bool  $strict
-     * @return self
      */
     public function andEqual($expr1, $expr2, $strict = true): self
     {
@@ -97,7 +86,6 @@ class Policy
      * @param  mixed  $expr1
      * @param  mixed  $expr2
      * @param  bool  $strict
-     * @return self
      */
     public function andNotEqual($expr1, $expr2, $strict = true): self
     {
@@ -112,7 +100,6 @@ class Policy
      * @param  mixed  $expr1
      * @param  mixed  $expr2
      * @param  bool  $strict
-     * @return self
      */
     public function orEqual($expr1, $expr2, $strict = true): self
     {
@@ -127,7 +114,6 @@ class Policy
      * @param  mixed  $expr1
      * @param  mixed  $expr2
      * @param  bool  $strict
-     * @return self
      */
     public function orNotEqual($expr1, $expr2, $strict = true): self
     {

--- a/app/Models/Dipa.php
+++ b/app/Models/Dipa.php
@@ -113,7 +113,7 @@ class Dipa extends Model
             ->select(['mak', 'id', 'uraian'])
             ->where('dipa_id', $dipaId)
             ->when($search, function ($query, $search) {
-                $keywords = explode('.', $search);
+                $keywords = explode('.', $search ?? '');
                 foreach ($keywords as $keyword) {
                     $query->where('mak', 'like', '%'.$keyword.'%')
                         ->orWhere('uraian', 'like', '%'.$keyword.'%');

--- a/app/Models/ShareLink.php
+++ b/app/Models/ShareLink.php
@@ -26,7 +26,7 @@ class ShareLink extends Model
             ->select(['mak', 'id', 'uraian'])
             ->where('dipa_id', ! empty($dipa) ? $dipa->id : null)
             ->when($search, function ($query, $search) {
-                $keywords = explode('.', $search);
+                $keywords = explode('.', $search ?? '');
                 foreach ($keywords as $keyword) {
                     $query->where('mak', 'like', '%'.$keyword.'%');
                 }

--- a/app/Nova/RapatInternal.php
+++ b/app/Nova/RapatInternal.php
@@ -344,7 +344,7 @@ class RapatInternal extends Resource
 
     protected static function afterValidation(NovaRequest $request, $validator)
     {
-        if (Helper::cekGanda(json_decode($request->peserta), 'peserta_user_id')) {
+        if (Helper::cekGanda(json_decode($request->peserta ?? '[]'), 'peserta_user_id')) {
             $validator->errors()->add('peserta', 'Terdapat duplikasi peserta');
         }
     }

--- a/app/Nova/TindakLanjut.php
+++ b/app/Nova/TindakLanjut.php
@@ -173,7 +173,7 @@ class TindakLanjut extends Resource
 
     protected static function afterValidation(NovaRequest $request, $validator)
     {
-        if (Helper::cekGanda(json_decode($request->penanggung_jawab), 'penanggung_jawab_id')) {
+        if (Helper::cekGanda(json_decode($request->penanggung_jawab ?? '[]'), 'penanggung_jawab_id')) {
             $validator->errors()->add('penanggung_jawab', 'Terdapat duplikasi penanggung jawab');
         }
     }


### PR DESCRIPTION
… 8.1+ compatibility

- Protect json_decode() from null json parameter (default to '')
- Protect round() from null num parameter (default to 0)
- Protect explode() from null string parameter (default to '')
- Affected: Helper, Api, GoogleDriveQuota, Policy, Nova resources, Models
- Behavior unchanged: null treated as appropriate default value per function
- All tests passing